### PR TITLE
Avoid potential overflow on 64 bit systems

### DIFF
--- a/bitmap_image.hpp
+++ b/bitmap_image.hpp
@@ -1502,7 +1502,7 @@ private:
    void create_bitmap()
    {
       row_increment_ = width_ * bytes_per_pixel_;
-      data_.resize(height_ * row_increment_);
+      data_.resize(static_cast<size_t>(height_) * static_cast<size_t>(row_increment_));
    }
 
    void load_bitmap()


### PR DESCRIPTION
Cast to 'size_type' before multiplication to avoid potential overflow on 64 bit systems, where size_t would equal 64 bit.